### PR TITLE
Refactor #49 goPrev refactoring and edit copyArray name

### DIFF
--- a/src/components/carrousel/index.tsx
+++ b/src/components/carrousel/index.tsx
@@ -16,17 +16,21 @@ interface CarrouselParams {
 }
 
 const Carrousel = (props: CarrouselParams) => {
-  const { goPrev, goNext, width, copyArray, handleDot, sliderRef } = useSlider({
-    array: props.array,
-  });
+  const { goPrev, goNext, width, addDataAtBothEnds, handleDot, sliderRef } =
+    useSlider({
+      array: props.array,
+    });
 
   return (
     <Wrapper>
       <Container>
         <CarrouselDirection onClick={goPrev} />
         <CardListWrapper>
-          <CardListContainer ref={sliderRef} size={width * copyArray.length}>
-            {copyArray.map((card) => (
+          <CardListContainer
+            ref={sliderRef}
+            size={width * addDataAtBothEnds.length}
+          >
+            {addDataAtBothEnds.map((card) => (
               <Card key={`$cardList_${card.id}`} card={card} />
             ))}
           </CardListContainer>

--- a/src/components/carrousel/useSlider.ts
+++ b/src/components/carrousel/useSlider.ts
@@ -7,18 +7,21 @@ interface UserSliderProps {
 }
 
 const useSlider = (props: UserSliderProps) => {
-  const copyArray = [...props.array];
-  const firstData = { ...copyArray[0], id: `first_${copyArray[0].id}` };
-  const lastData = {
-    ...copyArray[copyArray.length - 1],
-    id: `last_${copyArray[copyArray.length - 1].id}`,
+  const arrayLen = props.array.length;
+  const addDataAtBothEnds = [...props.array];
+  const firstData = {
+    ...addDataAtBothEnds[0],
+    id: `first_${addDataAtBothEnds[0].id}`,
   };
-  copyArray.unshift(lastData);
-  copyArray.push(firstData);
+  const lastData = {
+    ...addDataAtBothEnds[addDataAtBothEnds.length - 1],
+    id: `last_${addDataAtBothEnds[addDataAtBothEnds.length - 1].id}`,
+  };
+  addDataAtBothEnds.unshift(lastData);
+  addDataAtBothEnds.push(firstData);
 
   const sliderRef = useRef<HTMLDivElement>(null);
   const [idx, setIdx] = useState<number>(1);
-
   const [width, setWidth] = useState<number>(
     window.innerWidth >= 0 && window.innerWidth <= 425
       ? 250
@@ -26,8 +29,6 @@ const useSlider = (props: UserSliderProps) => {
       ? 450
       : 900,
   );
-
-  const arrayLen = props.array.length;
 
   useEffect(() => {
     const target = sliderRef.current;
@@ -72,7 +73,7 @@ const useSlider = (props: UserSliderProps) => {
     if (idx === 1) {
       setTimeout(() => {
         if (target) target.style.transitionDuration = '0ms';
-        setIdx(5);
+        setIdx(arrayLen);
       }, 500);
     }
     setIdx((prev) => prev - 1);
@@ -91,7 +92,7 @@ const useSlider = (props: UserSliderProps) => {
     goPrev,
     goNext,
     width,
-    copyArray,
+    addDataAtBothEnds,
     handleDot,
     sliderRef,
   };


### PR DESCRIPTION
## 작업 분류
- Refactor (리팩토링)


## 작업 개요
- goPrev기능 리팩토링 및 copyArray 변수 이름 변경

## 상세 내용
- useSlider의 goPrev기능에 첫번째에서 마지막으로 가는 코드에
   setIdx(5)가 아니라 setIdx(arrayLen)을 받아야해서 수정했음
- copyArray라는 이름이 다른사람이 보기에 어떤 배열인지 파악하기 어려울거같아 이름을
   addDataAtBothEnds로 변경